### PR TITLE
Add basic project skeleton

### DIFF
--- a/include/err.h
+++ b/include/err.h
@@ -1,0 +1,8 @@
+#ifndef _ERR_H
+#define _ERR_H
+
+void tx_print_errors(void);
+int tx_geterr(void);
+void tx_error_callback(int error, const char * description);
+
+#endif

--- a/include/termix.h
+++ b/include/termix.h
@@ -1,0 +1,7 @@
+#ifndef _TERMIX_H
+#define _TERMIX_H
+
+int tx_init(int argc, char * argv[]);
+int tx_run(void);
+
+#endif

--- a/src/err.c
+++ b/src/err.c
@@ -1,0 +1,86 @@
+#include <stddef.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <GLFW/glfw3.h>
+#include "err.h"
+
+#define MAX_ERROR_LOG_LENGTH 20
+
+char * error_log[MAX_ERROR_LOG_LENGTH] = { NULL };
+size_t log_entries = 0;
+
+void tx_print_errors(void)
+{
+	assert(log_entries != 0);
+
+	size_t i;
+	for (i = 0; i < log_entries; i++)
+	{
+		fprintf(stderr, "termix: error %zu: %s\n", i + 1, error_log[i]);
+		free(error_log[i]);
+	}
+
+	memset(error_log, 0, sizeof error_log);
+	log_entries = 0;
+}
+
+int tx_geterr(void)
+{
+	// Query OpenGL to see if there were any errors
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR)
+	{
+		if (log_entries >= MAX_ERROR_LOG_LENGTH)
+		{
+			fprintf(stderr, "termix: warning: no room in error log");
+			break;
+		}
+		else
+		{
+			char * str = NULL;
+			switch (error)
+			{
+			case GL_INVALID_ENUM:
+				str = "OpenGL: INVALID_ENUM";
+				break;
+			case GL_INVALID_VALUE:
+				str = "OpenGL: INVALID_VALUE";
+				break;
+			case GL_INVALID_OPERATION:
+				str = "OpenGL: INVALID_OPERATION";
+				break;
+			case GL_STACK_OVERFLOW:
+				str = "OpenGL: STACK_OVERFLOW";
+				break;
+			case GL_STACK_UNDERFLOW:
+				str = "OpenGL: STACK_UNDERFLOW";
+				break;
+			case GL_OUT_OF_MEMORY:
+				str = "OpenGL: OUT_OF_MEMORY";
+				break;
+			default:
+				str = "OpenGL: Unknown error";
+				break;
+			}
+			error_log[log_entries++] = strdup(str);
+		}
+	}
+	return log_entries == 0 ? 0 : -1;
+}
+
+// http://www.glfw.org/docs/latest/intro_guide.html#error_handling
+// http://www.glfw.org/docs/latest/group__errors.html
+void tx_error_callback(int error, const char * description)
+{
+	(void)error; // Suppress unused warning
+	if (log_entries >= MAX_ERROR_LOG_LENGTH)
+	{
+		fprintf(stderr, "warning: no room in error log");
+	}
+	else
+	{
+		error_log[log_entries++] = strdup(description);
+	}
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,40 +1,16 @@
-#include <stdio.h>
-#include <GLFW/glfw3.h>
+#include "termix.h"
 
-int main(void)
+int main(int argc, char * argv[])
 {
-	if (!glfwInit())
+	if (tx_init(argc, argv) != 0)
 	{
-		fprintf(stderr, "GLFW initialization failed\n");
 		return -1;
 	}
 
-	// Select OpenGL 2.1
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-	GLFWwindow * window = glfwCreateWindow(1280, 720, "Termix", NULL, NULL);
-	if (!window)
+	if (tx_run() != 0)
 	{
-		fprintf(stderr, "Window creation failedn");
 		return -1;
 	}
 
-	glfwMakeContextCurrent(window); // Binds the GL context to this thread
-	printf("Hello termix!\n");
-	printf("OpenGL information:\n");
-	printf("Version: %s\n", glGetString(GL_VERSION));
-	printf("GLSL Version: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
-	printf("Renderer: %s\n", glGetString(GL_RENDERER));
-	printf("Vendor: %s\n", glGetString(GL_VENDOR));
-
-	glClearColor(0.0f, 0.0f, 1.0f, 1.0f); // Blue
-	while (!glfwWindowShouldClose(window))
-	{
-		glfwPollEvents();
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // Clear screen
-		glfwSwapBuffers(window);
-	}
-
-	glfwDestroyWindow(window);
 	return 0;
 }

--- a/src/termix.c
+++ b/src/termix.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <GLFW/glfw3.h>
+#include "termix.h"
+#include "err.h"
+
+// We can easily tweak this later, just prevents high CPU usage for now
+#define FRAME_RATE 60
+
+void tx_draw(GLFWwindow * window);
+void tx_resize_callback(GLFWwindow * window, int width, int height);
+
+static void print_sysinfo(void)
+{
+	printf("OpenGL information:\n");
+	printf("Version: %s\n", glGetString(GL_VERSION));
+	printf("GLSL Version: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
+	printf("Renderer: %s\n", glGetString(GL_RENDERER));
+	printf("Vendor: %s\n", glGetString(GL_VENDOR));
+}
+
+int tx_init(int argc, char * argv[])
+{
+	// Suppress unused warnings for now
+	(void)argc;
+	(void)argv;
+
+	glfwSetErrorCallback(tx_error_callback);
+
+	if (!glfwInit())
+	{
+		fprintf(stderr, "termix: glfw initialization failed\n");
+		tx_print_errors();
+		return -1;
+	}
+
+	// See http://www.glfw.org/docs/latest/window_guide.html#window_hints
+	// Select OpenGL 2.1
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
+
+	// Set resizable and visible
+	glfwWindowHint(GLFW_RESIZABLE, 1);
+	glfwWindowHint(GLFW_VISIBLE, 1);
+
+	return 0;
+}
+
+int tx_run(void)
+{
+	GLFWwindow * window = glfwCreateWindow(1280, 720, "Termix", NULL, NULL);
+	if (!window)
+	{
+		fprintf(stderr, "termix: window creation failed\n");
+		tx_print_errors();
+		return -1;
+	}
+
+	// Binds the GL context to this thread
+	glfwMakeContextCurrent(window);
+
+	glfwSetWindowRefreshCallback(window, tx_draw);
+	glfwSetWindowSizeCallback(window, tx_resize_callback);
+
+#if !defined(NDEBUG)
+	print_sysinfo();
+#endif
+
+	glClearColor(0.0f, 0.0f, 1.0f, 1.0f); // Blue, just for testing
+	if (tx_geterr() != 0)
+	{
+		tx_print_errors();
+		return -1;
+	}
+
+	while (!glfwWindowShouldClose(window))
+	{
+		glfwPollEvents();
+		tx_draw(window);
+
+#if !defined(NDEBUG)
+		if (tx_geterr() != 0)
+		{
+			break;
+		}
+#endif
+		// GLFW 3.2 contains a nice function which we could use here
+		// Unfortunately not all package managers have updated to 3.2
+		// See http://www.glfw.org/docs/latest/group__window.html#ga605a178db92f1a7f1a925563ef3ea2cf
+		usleep(1000000 / FRAME_RATE);
+	}
+
+	glfwDestroyWindow(window);
+
+	if (tx_geterr() != 0)
+	{
+		tx_print_errors();
+		return -1;
+	}
+
+	return 0;
+}
+
+// Called on window resize
+void tx_resize_callback(GLFWwindow * window, int width, int height)
+{
+	tx_draw(window);
+	// TODO: Register window changing size
+	(void)width;
+	(void)height;
+}
+
+// Called during the render loop or on refresh
+void tx_draw(GLFWwindow * window)
+{
+	// Clear screen
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+	// Drawing goes here...
+
+	// Display
+	glfwSwapBuffers(window);
+}


### PR DESCRIPTION
You may want to take a look at the error handling code in `err.c` and see if that sort of model is a good basis, or if we want to do something different. This PR also makes the distinction between debug and non-debug which can be controlled through the preprocessor macro `NDEBUG`.

The next thing we ought to do is to keep track of the window width and height (which I may need to tweak for OSX retina displays).