### PR TITLE
clean *.orig files without cleaning build/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(OS),Linux)
     CFLAGS += -D_DEFAULT_SOURCE
 endif
 
-.PHONY: default all clean run format
+.PHONY: default all clean cleanformat run format
 .SUFFIXES:
 .SUFFIXES: .c .o
 default: all
@@ -31,11 +31,13 @@ $(DESTDIR):
 all: $(DESTDIR) $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) -o $(DESTDIR)/$(TARGET) $(LDLIBS)
 
-clean:
+clean: cleanformat
  	# Could be $(DESTDIR)/*, but in case $(DESTDIR) is not set...
 	rm -rf $(DESTDIR)
-	rm -f src/*.orig
-	rm -f include/*.orig
+
+cleanformat:
+	rm -rf src/*.orig
+	rm -rf include/*.orig
 
 run: all
 	./$(DESTDIR)/$(TARGET)


### PR DESCRIPTION
I figured over time as we make and modify more c files it may be helpful to be able to clean only the formatting. The cleanformat rule just does what clean did before, and the clean rule calls cleanformat.