### PR TITLE
Refactor and add error codes

### DIFF
--- a/include/err.h
+++ b/include/err.h
@@ -1,8 +1,48 @@
 #ifndef _ERR_H
 #define _ERR_H
 
-void tx_gl_print_errors(void);
-int  tx_gl_geterr(void);
-void tx_gl_error_callback(int error, const char * description);
+#include <stdarg.h>
+
+typedef enum
+{
+	E_NONE = 0,
+	E_GL,   // OpenGL error
+	E_GLFW, // GLFW error
+	E_FT,   // Freetype error
+	E_INVALID_PATH,
+	E_LOG_FULL,
+	E_NO_MEM,
+	E_OTHER
+} tx_err;
+
+/* First, checks to see if OpenGL has anything on its error stack. If it does, it appends
+ * those errors to the error log. Otherwise, it checks if there are any pending error
+ * in the error log and returns them. Usually this should be followed by a call to
+ * tx_print_errors, because we know there will be errors in the error log.
+ * Internal functions that directly return tx_err can usually skip this function and
+ * instead call tx_print_errors straightaway.
+ */
+tx_err tx_geterr(void);
+
+/* Prints any previous OpenGL or GLFW errors and removes them from the error log once
+ * that has been done.
+ */
+void tx_print_errors(void);
+
+/* Appends a message to the error log.
+ * The string is copied, so you can deallocate it if needed afterwards. The string should
+ * also not end in a newline (that is added to the output during tx_print_errors).
+ * It is suggested to use asprintf to dynamically create strings for this function.
+ * Returns E_LOG_FULL and immediately prints the description if there is no room.
+ */
+tx_err tx_errlog_append(const char * description);
+
+/* Same as the above, except writes a string according to a format instead.
+ * e.g tx_errlog_append_fmt("%s:%d", some_string, some_int);
+ */
+tx_err tx_errlog_append_fmt(const char * fmt, ...);
+
+// GLFW calls this whenever there's an error
+void tx_glfw_error_callback(int error, const char * description);
 
 #endif

--- a/include/font.h
+++ b/include/font.h
@@ -1,0 +1,15 @@
+#ifndef _FONT_H
+#define _FONT_H
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+#include "err.h"
+
+// In the future, we'll probably want to wrap FT_Face with our own struct, since
+// it will allow us to keep information such as the path where we loaded it from
+
+tx_err tx_load_fontface(FT_Library * ft, FT_Face * face, const char * path);
+tx_err tx_unload_fontface(FT_Face * face);
+
+#endif

--- a/include/termix.h
+++ b/include/termix.h
@@ -1,8 +1,10 @@
 #ifndef _TERMIX_H
 #define _TERMIX_H
 
-int tx_init(int argc, char * argv[]);
-int tx_run(void);
-int tx_cleanup(void);
+#include "err.h"
+
+tx_err tx_init(int argc, char * argv[]);
+tx_err tx_run(void);
+tx_err tx_cleanup(void);
 
 #endif

--- a/src/err.c
+++ b/src/err.c
@@ -11,7 +11,7 @@
 char * error_log[MAX_ERROR_LOG_LENGTH] = { NULL };
 size_t log_entries = 0;
 
-void tx_gl_print_errors(void)
+void tx_print_errors(void)
 {
 	assert(log_entries != 0);
 
@@ -26,61 +26,95 @@ void tx_gl_print_errors(void)
 	log_entries = 0;
 }
 
-int tx_gl_geterr(void)
+tx_err tx_geterr(void)
 {
 	// Query OpenGL to see if there were any errors
+	size_t num_gl_errors = 0;
 	GLenum error;
 	while ((error = glGetError()) != GL_NO_ERROR)
 	{
-		if (log_entries >= MAX_ERROR_LOG_LENGTH)
+		char * str = NULL;
+		num_gl_errors++;
+		switch (error)
 		{
-			fprintf(stderr, "termix: warning: no room in error log\n");
+		case GL_INVALID_ENUM:
+			str = "OpenGL: INVALID_ENUM";
+			break;
+		case GL_INVALID_VALUE:
+			str = "OpenGL: INVALID_VALUE";
+			break;
+		case GL_INVALID_OPERATION:
+			str = "OpenGL: INVALID_OPERATION";
+			break;
+		case GL_STACK_OVERFLOW:
+			str = "OpenGL: STACK_OVERFLOW";
+			break;
+		case GL_STACK_UNDERFLOW:
+			str = "OpenGL: STACK_UNDERFLOW";
+			break;
+		case GL_OUT_OF_MEMORY:
+			str = "OpenGL: OUT_OF_MEMORY";
+			break;
+		default:
+			str = "OpenGL: Unknown error";
 			break;
 		}
-		else
-		{
-			char * str = NULL;
-			switch (error)
-			{
-			case GL_INVALID_ENUM:
-				str = "OpenGL: INVALID_ENUM";
-				break;
-			case GL_INVALID_VALUE:
-				str = "OpenGL: INVALID_VALUE";
-				break;
-			case GL_INVALID_OPERATION:
-				str = "OpenGL: INVALID_OPERATION";
-				break;
-			case GL_STACK_OVERFLOW:
-				str = "OpenGL: STACK_OVERFLOW";
-				break;
-			case GL_STACK_UNDERFLOW:
-				str = "OpenGL: STACK_UNDERFLOW";
-				break;
-			case GL_OUT_OF_MEMORY:
-				str = "OpenGL: OUT_OF_MEMORY";
-				break;
-			default:
-				str = "OpenGL: Unknown error";
-				break;
-			}
-			error_log[log_entries++] = strdup(str);
-		}
+		tx_errlog_append(str);
 	}
-	return log_entries == 0 ? 0 : -1;
+
+	if (num_gl_errors > 0)
+		return E_GL;
+
+	// TODO: This might not be a GLFW error (could be one of ours)
+	return log_entries == 0 ? E_NONE : E_GLFW;
+}
+
+tx_err tx_errlog_append(const char * description)
+{
+	assert(description != NULL);
+	if (log_entries == MAX_ERROR_LOG_LENGTH)
+	{
+		fprintf(stderr, "termix: warning: no room in error log\n");
+		fprintf(stderr, "%s", description);
+		return E_LOG_FULL;
+	}
+
+	error_log[log_entries++] = strdup(description);
+	return E_NONE;
+}
+
+// printf style wrapper around tx_errlog_append
+tx_err tx_errlog_append_fmt(const char * fmt, ...)
+{
+	int size = 0;
+	va_list args;
+	va_list temp_args;
+
+	va_start(args, fmt);
+
+	// Get size
+	va_copy(temp_args, args);
+	size = vsnprintf(NULL, size, fmt, temp_args);
+	assert(size >= 0);
+	va_end(temp_args);
+
+	char * str = malloc(size + 1);
+	assert(str != NULL); // TODO: Actually handle the error (and possibly abort)
+
+	size = vsprintf(str, fmt, args);
+	assert(size >= 0);
+
+	va_end(args);
+
+	tx_err rv = tx_errlog_append(str); // TODO: Don't allocate twice. Wasteful!
+	free(str);
+	return rv;
 }
 
 // http://www.glfw.org/docs/latest/intro_guide.html#error_handling
 // http://www.glfw.org/docs/latest/group__errors.html
-void tx_gl_error_callback(int error, const char * description)
+void tx_glfw_error_callback(int error, const char * description)
 {
 	(void)error; // Suppress unused warning
-	if (log_entries >= MAX_ERROR_LOG_LENGTH)
-	{
-		fprintf(stderr, "warning: no room in error log\n");
-	}
-	else
-	{
-		error_log[log_entries++] = strdup(description);
-	}
+	tx_errlog_append(description);
 }

--- a/src/font.c
+++ b/src/font.c
@@ -1,0 +1,35 @@
+#include "font.h"
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+// TODO: FT_Face NEEDS to be calloc'd here before FT_New_Face, how are we going to ensure that?
+// See https://www.freetype.org/freetype2/docs/reference/ft2-user_allocation.html
+tx_err tx_load_fontface(FT_Library * ft, FT_Face * face, const char * path)
+{
+	assert(ft != NULL); assert(face != NULL); assert(path != NULL);
+
+	if (FT_New_Face(*ft, path, 0, face) != 0)
+	{
+		tx_errlog_append_fmt("failed to load font face from path %s", path);
+
+		// Assume it's invalid path even though we aren't sure
+		// TODO: Check the return value of FT_New_Face to see what failed
+		return E_INVALID_PATH;
+	}
+
+	return E_NONE;
+}
+
+tx_err tx_unload_fontface(FT_Face * face)
+{
+	if (FT_Done_Face(*face) != 0)
+	{
+		// TODO: Include path of font face in this message
+		// We'll need our wrapper struct for that probably
+		tx_errlog_append("failed to unload font face");
+		return E_FT;
+	}
+
+	return E_NONE;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -2,20 +2,14 @@
 
 int main(int argc, char * argv[])
 {
-	if (tx_init(argc, argv) != 0)
-	{
+	if (tx_init(argc, argv) != E_NONE)
 		return -1;
-	}
 
-	if (tx_run() != 0)
-	{
+	if (tx_run() != E_NONE)
 		return -1;
-	}
 
-	if (tx_cleanup() != 0)
-	{
+	if (tx_cleanup() != E_NONE)
 		return -1;
-	}
 
 	return 0;
 }

--- a/src/termix.c
+++ b/src/termix.c
@@ -4,13 +4,16 @@
 #include FT_FREETYPE_H
 #include <GLFW/glfw3.h>
 #include "termix.h"
-#include "err.h"
+#include "font.h"
 
 // We can easily tweak this later, just prevents high CPU usage for now
 #define FRAME_RATE 60
 
 void tx_draw(GLFWwindow * window);
 void tx_resize_callback(GLFWwindow * window, int width, int height);
+
+// TODO: Move this into a struct somewhere
+FT_Library ft;
 
 static void print_sysinfo(void)
 {
@@ -21,19 +24,26 @@ static void print_sysinfo(void)
 	printf("Vendor: %s\n", glGetString(GL_VENDOR));
 }
 
-int tx_init(int argc, char * argv[])
+tx_err tx_init(int argc, char * argv[])
 {
 	// Suppress unused warnings for now
 	(void)argc;
 	(void)argv;
 
-	glfwSetErrorCallback(tx_gl_error_callback);
+	glfwSetErrorCallback(tx_glfw_error_callback);
 
-	if (!glfwInit())
+	if (glfwInit() == 0)
 	{
 		fprintf(stderr, "termix: glfw initialization failed\n");
-		tx_gl_print_errors();
-		return -1;
+		tx_print_errors(); // Might be some stuff in the error log
+		return E_GLFW;
+	}
+
+	/* Freetype init */
+	if (FT_Init_FreeType(&ft) != 0)
+	{
+		fprintf(stderr, "termix: freetype initializaion failed\n");
+		return E_FT;
 	}
 
 	// See http://www.glfw.org/docs/latest/window_guide.html#window_hints
@@ -46,17 +56,18 @@ int tx_init(int argc, char * argv[])
 	glfwWindowHint(GLFW_RESIZABLE, 1);
 	glfwWindowHint(GLFW_VISIBLE, 1);
 
-	return 0;
+	return E_NONE;
 }
 
-int tx_run(void)
+tx_err tx_run(void)
 {
+	tx_err err = E_NONE;
 	GLFWwindow * window = glfwCreateWindow(1280, 720, "Termix", NULL, NULL);
 	if (!window)
 	{
 		fprintf(stderr, "termix: window creation failed\n");
-		tx_gl_print_errors();
-		return -1;
+		tx_print_errors();
+		return E_GLFW;
 	}
 
 	// Binds the GL context to this thread
@@ -70,34 +81,27 @@ int tx_run(void)
 #endif
 
 	glClearColor(0.0f, 0.0f, 1.0f, 1.0f); // Blue, just for testing
-	if (tx_gl_geterr() != 0)
-	{
-		tx_gl_print_errors();
-		return -1;
-	}
-
-	/* Freetype init */
-	FT_Library ft;
-	if(FT_Init_FreeType(&ft))
-	{
-		fprintf(stderr, "Could not init freetype library\n");
-		return -1;
-	}
 
 	FT_Face face;
-	char fontface_name[] = "/usr/share/fonts/corefonts/arial.ttf";
-	if(FT_New_Face(ft, fontface_name, 0, &face))
+	char fontface_name[] = "/usr/share/fonts/truetype/FiraSans/FiraSans-Regular.ttf";
+	if ((err = tx_load_fontface(&ft, &face, fontface_name)) != E_NONE)
 	{
-		fprintf(stderr, "Could not open font %s\n", fontface_name);
-		return 1;
-	}
-	FT_Set_Pixel_Sizes(face, 0, 10);
-	if(FT_Load_Char(face, 'X', FT_LOAD_RENDER))
-	{
-		fprintf(stderr, "Could not load character 'X'\n");
-		return 1;
+		tx_print_errors();
+		return err;
 	}
 
+	FT_Set_Pixel_Sizes(face, 0, 10);
+	if (FT_Load_Char(face, 'X', FT_LOAD_RENDER) != 0)
+	{
+		fprintf(stderr, "termix: could not load character 'X'\n");
+		return E_FT;
+	}
+
+	if ((err = tx_unload_fontface(&face)) != E_NONE)
+	{
+		tx_print_errors();
+		return err;
+	}
 
 
 	while (!glfwWindowShouldClose(window))
@@ -106,34 +110,40 @@ int tx_run(void)
 		tx_draw(window);
 
 #if !defined(NDEBUG)
-		if (tx_gl_geterr() != 0)
-		{
+		if ((err = tx_geterr()) != E_NONE)
 			break;
-		}
 #endif
-		// GLFW 3.2 contains a nice function which we could use here
+		// TODO: GLFW 3.2 contains a nice function which we could use here
 		// Unfortunately not all package managers have updated to 3.2
 		// See http://www.glfw.org/docs/latest/group__window.html#ga605a178db92f1a7f1a925563ef3ea2cf
+		// 1000000 microseconds in a second
 		usleep(1000000 / FRAME_RATE);
 	}
 
 	glfwDestroyWindow(window);
 
-	return 0;
+	return err;
 }
 
-int tx_cleanup(void)
+tx_err tx_cleanup(void)
 {
+	tx_err err = E_NONE;
 	glfwTerminate();
 
-	// Print errors to ensure that we don't leak memory from the log
-	if (tx_gl_geterr() != 0)
+	if (FT_Done_FreeType(ft) != 0)
 	{
-		tx_gl_print_errors();
-		return -1;
+		fprintf(stderr, "termix: could not cleanup freetype\n");
+		return E_FT;
 	}
 
-	return 0;
+	// Print errors to ensure that we don't leak memory from the log
+	if ((err = tx_geterr()) != E_NONE)
+	{
+		tx_print_errors();
+		return err;
+	}
+
+	return E_NONE;
 }
 
 // Called on window resize


### PR DESCRIPTION
Ok, big commit here, apologies for this. I initially started out by trying to just add the error codes but that meant I needed to touch a lot of code in order to do so. Regardless I think it was a good idea to do this now rather than later on, before we run into any issues.

Firstly, I added an enum which describes all the error codes which we might run into, including internal errors. This allows functions to indicate if it succeeded (i.e it returned E_NONE which is equal to zero) or if it failed (it returned another tx_err value as defined in err.h).

I renamed the error handling functions because I didn't believe they were accurate: `tx_gl_error_callback` now becomes `tx_glfw_error_callback`, `tx_gl_geterr` becomes `tx_geterr` again (because it handles GLFW and OpenGL errors while also checking to see if the error log is clear alltogether) and `tx_gl_print_errors` now becomes `tx_print_errors` again too (because it prints any sort of error that might find itself in the error log).

Secondly, I extracted a couple of FreeType functions into `font.c`, because we're probably going to need that eventually even if not right now.

One current thing to note is that the path to the font at `/usr/share/fonts/corefonts/arial.ttf` isn't vaild on either of the systems I tried (OSX, Ubuntu). Obviously it is just temporary but it still means that I can't test things out, so we may want to change that.

Sorry for the wall of text, I should be able to get started on the OpenGL rendering stuff today or tomorrow.

Let me know if there are any issues.